### PR TITLE
pry-nav dependency update

### DIFF
--- a/pry-nav.gemspec
+++ b/pry-nav.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |gem|
 
   # Dependencies
   gem.required_ruby_version = '>= 1.9.2'
-  gem.add_runtime_dependency 'pry', '~> 0.9.7.4'
+  gem.add_runtime_dependency 'pry', '~> 0.9.8.0'
 end


### PR DESCRIPTION
New pry is out and so dependency update is required.
