### PR TITLE
Support 1.8.7

### DIFF
--- a/lib/pry-nav/commands.rb
+++ b/lib/pry-nav/commands.rb
@@ -25,8 +25,8 @@ module PryNav
       def breakout_navigation(action, times)
         _pry_.binding_stack.clear     # Clear the binding stack.
         throw :breakout_nav, {        # Break out of the REPL loop and
-          action: action,             #   signal the tracer.
-          times:  times
+          :action => action,          #   signal the tracer.
+          :times =>  times
         }
       end
 

--- a/pry-nav.gemspec
+++ b/pry-nav.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   # Dependencies
-  gem.required_ruby_version = '>= 1.9.2'
+  gem.required_ruby_version = '>= 1.8.7'
   gem.add_runtime_dependency 'pry', '~> 0.9.8.1'
 end


### PR DESCRIPTION
Hi Nixme,

Thanks for pry-nav, I just did some playing around and it turns out that the gem works as-expected on Ruby-1.8.7 too.

I've attached a patch that changes the 1.9 only syntax to 1.8.7 compatible, and updated the Gemspec appropriately.

As this patch conflicts with the one by Styx, I've resolved the merge-conflict, and put the result so you can get it with:

```
git pull git@github.com:ConradIrwin/pry-nav.git merged
```

Thanks,
Conrad
