### PR TITLE
eliminate need for separate require 'pry-nav', closes #9

### DIFF
--- a/lib/pry-nav/cli.rb
+++ b/lib/pry-nav/cli.rb
@@ -1,0 +1,1 @@
+require 'pry-nav'


### PR DESCRIPTION
- Pry loads the cli.rb for a plugin at startup, rather than at Pry.start().
  By adding this file we ensure that pry-nav's monkeypatch applies without requiring an additional
  require 'pry-nav' by the user.
