### PR TITLE
Safer monkey-patching of Pry.start/.teardown

### DIFF
--- a/lib/pry-nav/pry_ext.rb
+++ b/lib/pry-nav/pry_ext.rb
@@ -2,19 +2,21 @@ require 'pry'
 require 'pry-nav/tracer'
 
 class << Pry
-  alias_method :start_existing, :start
+  alias_method :start_without_pry_nav, :start
 
-  def start(target = TOPLEVEL_BINDING, options = {})
+  def start_with_pry_nav(target = TOPLEVEL_BINDING, options = {})
     old_options = options.reject { |k, _| k == :pry_remote }
 
     if target.is_a?(Binding) && PryNav.check_file_context(target)
       # Wrap the tracer around the usual Pry.start
       PryNav::Tracer.new(options).run do
-        start_existing(target, old_options)
+        start_without_pry_nav(target, old_options)
       end
     else
       # No need for the tracer unless we have a file context to step through
-      start_existing(target, old_options)
+      start_without_pry_nav(target, old_options)
     end
   end
+
+  alias_method :start, :start_with_pry_nav
 end

--- a/lib/pry-nav/pry_remote_ext.rb
+++ b/lib/pry-nav/pry_remote_ext.rb
@@ -21,11 +21,12 @@ module PryRemote
     end
 
     # Override to reset our saved global current server session.
-    alias_method :teardown_existing, :teardown
-    def teardown
-      teardown_existing
+    alias_method :teardown_without_pry_nav, :teardown
+    def teardown_with_pry_nav
+      teardown_without_pry_nav
       PryNav.current_remote_server = nil
     end
+    alias_method :teardown, :teardown_with_pry_nav
   end
 end
 


### PR DESCRIPTION
Allows other plugins to do the same without triggering a SystemStackError.
