### PR TITLE
Allowing pry 0.10.x

### DIFF
--- a/pry-nav.gemspec
+++ b/pry-nav.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |gem|
 
   # Dependencies
   gem.required_ruby_version = '>= 1.8.7'
-  gem.add_runtime_dependency 'pry', '~> 0.9.10'
+  gem.add_runtime_dependency 'pry', '>= 0.9.10', '< 0.11.0'
   gem.add_development_dependency 'pry-remote', '~> 0.1.6'
 end


### PR DESCRIPTION
Since `pry` has updated, this change to the version range will allow `pry-nav` to be around in a set of gems when `pry` 0.10.x is used.

My work requires me to continue supporting Ruby 1.8.7 (:grimacing:), so I make use of `pry-nav` instead of some of the newer, neater tools you've made @nixme.

I've done some basic testing locally and things seem functional with the new version of `pry`. Is there further specific checking you'd want done to clear the way for this change?
