### PR TITLE
Add instructions for JRuby in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Include `-Xcext.enabled=true` and `--debug` in your `JRUBY_OPTS`. For example yo
 export JRUBY_OPTS="-Xcext.enabled=true --debug"
 ```
 
+Adding these flags isn't required, but avoiding them may mean your `next` commands function like `step`s. See [this issue](https://github.com/nixme/pry-nav/issues/19) for more discussion.
+
 * * *
 
 pry-nav [![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/nixme/pry-nav/trend.png)](https://bitdeli.com/free "Bitdeli Badge")

--- a/README.md
+++ b/README.md
@@ -3,6 +3,13 @@
 
 Same features as **pry-nav** but with faster tracing, breakpoints, and more.
 
+### Using JRuby?
+Include `-Xcext.enabled=true` and `--debug` in your `JRUBY_OPTS`. For example you might have this in your `~/.bashrc` or `~/.bash_profile`:
+
+```bash
+export JRUBY_OPTS="-Xcext.enabled=true --debug"
+```
+
 * * *
 
 pry-nav [![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/nixme/pry-nav/trend.png)](https://bitdeli.com/free "Bitdeli Badge")


### PR DESCRIPTION
As stated in [this issue](https://github.com/nixme/pry-nav/issues/19), adding a few flags to your `JRUBY_OPTS` makes pry-nav usable under JRuby. This PR adds the info to the readme.