### PR TITLE
Update README to mention JRuby and fix circular require warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## UNRELEASED
+
+* Fix circular require warning.
+
 ## 0.2.4 (2014-06-25)
 
 * Support Pry 0.10

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
 # Specify your gem's dependencies in pry-nav.gemspec
 gemspec

--- a/README.md
+++ b/README.md
@@ -1,32 +1,33 @@
-### Using MRI 1.9.2+? Switch to [**pry-debugger**][pry-debugger].
-### Using MRI 2+? Switch to [**pry-byebug**][pry-byebug].
+# pry-nav
 
-Same features as **pry-nav** but with faster tracing, breakpoints, and more.
+_A simple execution control add-on for [Pry][pry]._
 
-* * *
+Using MRI? We recommend [`pry-byebug`][pry-byebug] instead!
 
-pry-nav [![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/nixme/pry-nav/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
-=======
+Compatible with ![JRuby](https://raw.githubusercontent.com/jruby/collateral/master/logos/PNGs/logo-with-type/full-color/jruby-logo-logo-with-type-small.png) >= 9.1.3.0.
 
-_Simple execution control in Pry_
-
-Teaches [Pry][pry] about **step**, **next**, and **continue** to create a simple
+Teaches [Pry][pry] about `step`, `next`, and `continue` to create a simple
 debugger.
 
-To use, invoke pry normally:
+To use, invoke `pry` normally:
 
 ```ruby
 def some_method
   binding.pry          # Execution will stop here.
-  puts 'Hello World'   # Run 'step' or 'next' in the console to move here.
+  puts 'Hello, World!' # Run 'step' or 'next' in the console to move here.
 end
 ```
 
-**pry-nav** is not yet thread-safe, so only use in single-threaded environments.
+When using JRuby, you also need to run it with the `--debug` flag. You can
+also add the flag to your `JRUBY_OPTS` environment variable for it to apply
+when running any ruby command, but do note that even when not making use of
+`pry` this has a big impact on JRuby performance.
 
-Rudimentary support for [pry-remote][pry-remote] (>= 0.1.1) is also included.
-Ensure pry-remote is loaded or required before pry-nav. For example, in a
-Gemfile:
+`pry-nav` is not yet thread-safe, so only use in single-threaded environments.
+
+Rudimentary support for [`pry-remote`][pry-remote] (>= 0.1.1) is also included.
+Ensure `pry-remote` is loaded or required before `pry-nav`. For example, in a
+`Gemfile`:
 
 ```ruby
 gem 'pry'
@@ -42,36 +43,30 @@ Pry.commands.alias_command 's', 'step'
 Pry.commands.alias_command 'n', 'next'
 ```
 
-Debugging functionality is implemented through
+Please note that debugging functionality is implemented through
 [`set_trace_func`][set_trace_func], which imposes a large performance
-penalty. **pry-nav** traces only when necessary, but due to a workaround for a
-[bug in 1.9.2][ruby-bug], the console will feel sluggish. Use 1.9.3 for best
-results and almost no performance penalty.
-
+penalty.
 
 ## Contributors
 
-* Gopal Patel (@nixme)
-* John Mair (@banister)
-* Conrad Irwin (@ConradIrwin)
-* Benjamin R. Haskell (@benizi)
-* Jason R. Clark (@jasonrclark)
+* Gopal Patel ([@nixme](https://github.com/nixme))
+* John Mair ([@banister](https://github.com/banister))
+* Conrad Irwin ([@ConradIrwin](https://github.com/ConradIrwin))
+* Benjamin R. Haskell ([@benizi](https://github.com/benizi))
+* Jason R. Clark ([@jasonrclark](https://github.com/jasonrclark))
+* Ivo Anjo ([@ivoanjo](https://github.com/ivoanjo))
 
 Patches and bug reports are welcome. Just send a [pull request][pullrequests] or
 file an [issue][issues]. [Project changelog][changelog].
 
-
 ## Acknowledgments
 
-- Ruby stdlib's [debug.rb][debug.rb]
-- [@Mon-Ouie][Mon-Ouie]'s [pry_debug][pry_debug]
+* Ruby stdlib's [debug.rb][debug.rb]
+* [@Mon-Ouie][Mon-Ouie]'s [pry_debug][pry_debug]
 
-
-[pry-debugger]:   https://github.com/nixme/pry-debugger
-[pry]:            http://pry.github.com
+[pry]:            http://pryrepl.org/
 [pry-remote]:     https://github.com/Mon-Ouie/pry-remote
 [set_trace_func]: http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-set_trace_func
-[ruby-bug]:       http://redmine.ruby-lang.org/issues/3921
 [pullrequests]:   https://github.com/nixme/pry-nav/pulls
 [issues]:         https://github.com/nixme/pry-nav/issues
 [changelog]:      https://github.com/nixme/pry-nav/blob/master/CHANGELOG.md

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
+### Using MRI? We recommend [**pry-byebug**][pry-byebug] instead!
+
 # pry-nav
 
 _A simple execution control add-on for [Pry][pry]._
-
-Using MRI? We recommend [`pry-byebug`][pry-byebug] instead!
 
 Compatible with ![JRuby](https://raw.githubusercontent.com/jruby/collateral/master/logos/PNGs/logo-with-type/full-color/jruby-logo-logo-with-type-small.png) >= 9.1.3.0.
 

--- a/lib/pry-nav/commands.rb
+++ b/lib/pry-nav/commands.rb
@@ -1,4 +1,4 @@
-require 'pry'
+require 'pry' unless defined? Pry
 
 module PryNav
   Commands = Pry::CommandSet.new do

--- a/lib/pry-nav/pry_ext.rb
+++ b/lib/pry-nav/pry_ext.rb
@@ -1,4 +1,4 @@
-require 'pry'
+require 'pry' unless defined? Pry
 require 'pry-nav/tracer'
 
 class << Pry

--- a/lib/pry-nav/pry_remote_ext.rb
+++ b/lib/pry-nav/pry_remote_ext.rb
@@ -1,3 +1,4 @@
+require 'pry' unless defined? Pry
 require 'pry-remote'
 
 module PryRemote

--- a/lib/pry-nav/tracer.rb
+++ b/lib/pry-nav/tracer.rb
@@ -1,4 +1,4 @@
-require 'pry'
+require 'pry' unless defined? Pry
 
 module PryNav
   class Tracer


### PR DESCRIPTION
This PR:
* updates the README to always recommend `pry-byebug` for MRI users (as you should know better if you're still on < 1.9)
* cleans up a circular require warning
* bumps the gem version to 0.2.5