### PR TITLE
Drop support for old ruby versions (< 2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## UNRELEASED
 
 * Fix circular require warning.
+* Drop support for ruby < 2.1.
 
 ## 0.2.4 (2014-06-25)
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,2 @@
 #!/usr/bin/env rake
-require "bundler/gem_tasks"
+require 'bundler/gem_tasks'

--- a/lib/pry-nav/commands.rb
+++ b/lib/pry-nav/commands.rb
@@ -20,10 +20,11 @@ module PryNav
     helpers do
       def breakout_navigation(action, times)
         _pry_.binding_stack.clear     # Clear the binding stack.
-        throw :breakout_nav, {        # Break out of the REPL loop and
-          :action => action,          #   signal the tracer.
-          :times =>  times
-        }
+        throw(
+          :breakout_nav,              # Break out of the REPL loop and
+          action: action,             #   signal the tracer.
+          times: times,
+        )
       end
 
       # Ensures that a command is executed in a local file context.

--- a/lib/pry-nav/pry_ext.rb
+++ b/lib/pry-nav/pry_ext.rb
@@ -2,7 +2,7 @@ require 'pry' unless defined? Pry
 require 'pry-nav/tracer'
 
 class << Pry
-  alias_method :start_without_pry_nav, :start
+  alias start_without_pry_nav start
 
   def start_with_pry_nav(target = TOPLEVEL_BINDING, options = {})
     old_options = options.reject { |k, _| k == :pry_remote }
@@ -18,5 +18,5 @@ class << Pry
     end
   end
 
-  alias_method :start, :start_with_pry_nav
+  alias start start_with_pry_nav
 end

--- a/lib/pry-nav/pry_remote_ext.rb
+++ b/lib/pry-nav/pry_remote_ext.rb
@@ -14,20 +14,21 @@ module PryRemote
       end
 
       setup
-      Pry.start @object, {
-        :input  => client.input_proxy,
-        :output => client.output,
-        :pry_remote => true
-      }
+      Pry.start(
+        @object,
+        input: client.input_proxy,
+        output: client.output,
+        pry_remote: true,
+      )
     end
 
     # Override to reset our saved global current server session.
-    alias_method :teardown_without_pry_nav, :teardown
+    alias teardown_without_pry_nav teardown
     def teardown_with_pry_nav
       teardown_without_pry_nav
       PryNav.current_remote_server = nil
     end
-    alias_method :teardown, :teardown_with_pry_nav
+    alias teardown teardown_with_pry_nav
   end
 end
 
@@ -36,7 +37,5 @@ end
 # PryNav::Tracer#run doesn't have a chance to cleanup.
 at_exit do
   set_trace_func nil
-  if PryNav.current_remote_server
-    PryNav.current_remote_server.teardown
-  end
+  PryNav.current_remote_server.teardown if PryNav.current_remote_server
 end

--- a/lib/pry-nav/tracer.rb
+++ b/lib/pry-nav/tracer.rb
@@ -2,14 +2,14 @@ require 'pry' unless defined? Pry
 
 module PryNav
   class Tracer
-    def initialize(pry_start_options = {}, &block)
+    def initialize(pry_start_options = {})
       @step_in_lines = -1                      # Break after this many lines
       @frames_when_stepping = nil              # Only break at this frame level
       @frames = 0                              # Traced stack frame level
       @pry_start_options = pry_start_options   # Options to use for Pry.start
     end
 
-    def run(&block)
+    def run
       # For performance, disable any tracers while in the console.
       stop
 
@@ -57,10 +57,9 @@ module PryNav
       end
     end
 
+    private
 
-   private
-
-    def tracer(event, file, line, id, binding, klass)
+    def tracer(event, file, _line, _id, binding, _klass)
       # Ignore traces inside pry-nav code
       return if file && TRACE_IGNORE_FILES.include?(File.expand_path(file))
 
@@ -78,7 +77,7 @@ module PryNav
         end
 
         # Break on this line?
-        Pry.start(binding, @pry_start_options) if @step_in_lines == 0
+        Pry.start(binding, @pry_start_options) if @step_in_lines.zero?
 
       when 'call', 'class'
         @frames += 1         # Track entering a frame

--- a/lib/pry-nav/tracer.rb
+++ b/lib/pry-nav/tracer.rb
@@ -11,9 +11,7 @@ module PryNav
 
     def run(&block)
       # For performance, disable any tracers while in the console.
-      # Unfortunately doesn't work in 1.9.2 because of
-      # http://redmine.ruby-lang.org/issues/3921. Works fine in 1.8.7 and 1.9.3.
-      stop unless RUBY_VERSION == '1.9.2'
+      stop
 
       return_value = nil
       command = catch(:breakout_nav) do      # Coordinates with PryNav::Commands
@@ -25,7 +23,6 @@ module PryNav
       if process_command(command)
         start
       else
-        stop if RUBY_VERSION == '1.9.2'
         if @pry_start_options[:pry_remote] && PryNav.current_remote_server
           PryNav.current_remote_server.teardown
         end

--- a/lib/pry-nav/version.rb
+++ b/lib/pry-nav/version.rb
@@ -1,3 +1,3 @@
 module PryNav
-  VERSION = '0.2.4'
+  VERSION = '0.2.4'.freeze
 end

--- a/pry-nav.gemspec
+++ b/pry-nav.gemspec
@@ -17,8 +17,9 @@ Gem::Specification.new do |gem|
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   gem.require_paths = ["lib"]
 
-  # Dependencies
-  gem.required_ruby_version = '>= 1.8.7'
+  gem.required_ruby_version = '>= 2.1.0'
+
   gem.add_runtime_dependency 'pry', '>= 0.9.10', '< 0.11.0'
+
   gem.add_development_dependency 'pry-remote', '~> 0.1.6'
 end

--- a/pry-nav.gemspec
+++ b/pry-nav.gemspec
@@ -12,10 +12,10 @@ Gem::Specification.new do |gem|
   gem.summary       = 'Simple execution navigation for Pry.'
   gem.description   = "Turn Pry into a primitive debugger. Adds 'step' and 'next' commands to control execution."
 
-  gem.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  gem.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   gem.files         = `git ls-files`.split("\n")
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  gem.require_paths = ["lib"]
+  gem.require_paths = ['lib']
 
   gem.required_ruby_version = '>= 2.1.0'
 


### PR DESCRIPTION
This PR builds on top of #26 and drops support for non-upstream-supported ruby versions (e.g. anything less than 2.1). It also includes a number of minor style cleanups, as suggested by rubocop.
