### PR TITLE
Allow newer versions of pry to be used

### DIFF
--- a/pry-nav.gemspec
+++ b/pry-nav.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |gem|
 
   # Dependencies
   gem.required_ruby_version = '>= 1.8.7'
-  gem.add_runtime_dependency 'pry', '>= 0.9.10', '< 0.12.0'
+  gem.add_runtime_dependency 'pry', '>= 0.9.10', '< 0.13.0'
   gem.add_development_dependency 'pry-remote', '~> 0.1.6'
 end


### PR DESCRIPTION
We really need a version upgrade of `pry-nav` to be able to use the latest versions of `pry`. `pry-nav` has been preventing other upgrades.