### PR TITLE
Fix ruby 2.7 warning

### DIFF
--- a/lib/pry-nav.rb
+++ b/lib/pry-nav.rb
@@ -14,7 +14,12 @@ module PryNav
   # Checks that a binding is in a local file context. Extracted from
   # https://github.com/pry/pry/blob/master/lib/pry/default_commands/context.rb
   def check_file_context(target)
-    file = target.eval('__FILE__')
+    file = if target.respond_to?(:source_location)
+      target.source_location.first
+    else
+      target.eval('__FILE__')
+    end
+
     file == Pry.eval_path || (file !~ /(\(.*\))|<.*>/ && file != '' && file != '-e')
   end
 


### PR DESCRIPTION
> warning: __FILE__ in eval may not return location in binding; use Binding#source_location instead