### PR TITLE
Update pry dependency to `< 0.14.0`

### DIFF
--- a/pry-nav.gemspec
+++ b/pry-nav.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |gem|
 
   # Dependencies
   gem.required_ruby_version = '>= 1.8.7'
-  gem.add_runtime_dependency 'pry', '>= 0.9.10', '< 0.13.0'
+  gem.add_runtime_dependency 'pry', '>= 0.9.10', '< 0.14.0'
   gem.add_development_dependency 'pry-remote', '~> 0.1.6'
 end


### PR DESCRIPTION
pry 0.13.0 is released: https://github.com/pry/pry/blob/master/CHANGELOG.md#v0130-march-21-2020

It doesn't look like `pry-nav` is using any of the deprecated or deleted
functionalities.