### PR TITLE
Eliminate eval(__FILE__) warning for Ruby 2.6+

### DIFF
--- a/lib/pry-nav.rb
+++ b/lib/pry-nav.rb
@@ -8,13 +8,17 @@ require 'pry-nav/pry_remote_ext' if defined? PryRemote
 
 module PryNav
   TRACE_IGNORE_FILES = Dir[File.join(File.dirname(__FILE__), '**', '*.rb')].map { |f| File.expand_path(f) }
+  MIN_RUBY_VERSION_BINDING_SOURCE = 2.6
 
   extend self
 
   # Checks that a binding is in a local file context. Extracted from
   # https://github.com/pry/pry/blob/master/lib/pry/default_commands/context.rb
   def check_file_context(target)
-    file = target.eval('__FILE__')
+    file = RUBY_VERSION.to_f >= MIN_RUBY_VERSION_BINDING_SOURCE ?
+      target.source_location :
+      target.eval('__FILE__')
+
     file == Pry.eval_path || (file !~ /(\(.*\))|<.*>/ && file != '' && file != '-e')
   end
 


### PR DESCRIPTION
`eval(__FILE__)` gives a warning in the console with Ruby 2.6+. This PR eliminates it.