### PR TITLE
Remove the upper bound of pry version

### DIFF
--- a/pry-nav.gemspec
+++ b/pry-nav.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |gem|
 
   # Dependencies
   gem.required_ruby_version = '>= 1.8.7'
-  gem.add_runtime_dependency 'pry', '>= 0.9.10', '< 0.13.0'
+  gem.add_runtime_dependency 'pry', '>= 0.9.10'
   gem.add_development_dependency 'pry-remote', '~> 0.1.6'
 end


### PR DESCRIPTION
This is related to #33. Since this keeps coming up, I figured it might be a good idea to remove the limit entirely.

There are still several things that `pry-byebug` handles differently than `pry-nav` and `pry-stack_explorer`, and I prefer the functionality of the older stack. 