### PR TITLE
Remove duplicate required_ruby_version from gemspec

### DIFF
--- a/pry-nav.gemspec
+++ b/pry-nav.gemspec
@@ -18,8 +18,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.required_ruby_version = '>= 2.1.0'
-
-  gem.required_ruby_version = '>= 1.8.7'
   gem.add_runtime_dependency 'pry', '>= 0.9.10', '< 0.15'
   gem.add_development_dependency 'rake'
 end


### PR DESCRIPTION
Oops, it looks like there was a duplicate `required_ruby_version` entry.