### PR TITLE
Update pry dependency to support pry 0.15

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,5 @@ gemspec
 
 gem "test-unit"
 
-gem "pry", "~> 0.14.1"
+gem "pry", "~> 0.15"
 gem "pry-remote"

--- a/pry-nav.gemspec
+++ b/pry-nav.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.required_ruby_version = '>= 2.1.0'
-  gem.add_runtime_dependency 'pry', '>= 0.9.10', '< 0.15'
+  gem.add_runtime_dependency 'pry', '>= 0.9.10', '< 0.16'
   gem.add_development_dependency 'rake'
 end


### PR DESCRIPTION
### Description
This PR removes the dependency on pry < 0.15.

### Reason for PR:
I get this warning after upgrading to Ruby 3.4.1:

```
versions/3.4.1/lib/ruby/gems/3.4.0/gems/pry-0.14.2/lib/pry/command_state.rb:3: warning: .rbenv/versions/3.4.1/lib/ruby/3.4.0/ostruct.rb was loaded from the standard library, [250/5650]
o longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
Also please contact the author of pry-0.14.2 to request adding ostruct into its gemspec.
ruby/3.4.1 isn't supported by this pry-doc version
```

But `pry-nav` is preventing me from upgrading to pry-0.15 where the issue has been fixed.